### PR TITLE
Preserve original image aspect ratio within 16:9 preview container

### DIFF
--- a/app/main_window.py
+++ b/app/main_window.py
@@ -51,7 +51,6 @@ class MainWindow(QMainWindow):
         # Set fixed size with 16:9 aspect ratio (7680:4320 scaled down)
         self.preview_label.setFixedSize(768, 432)  # 16:9 aspect ratio
         self.preview_label.setStyleSheet("border: 1px solid gray;")
-        self.preview_label.setScaledContents(True)  # Scale image to fit the label
         self.layout.addWidget(self.preview_label)
 
         # Processing Summary
@@ -151,8 +150,13 @@ class MainWindow(QMainWindow):
 
         pixmap = QPixmap.fromImage(q_image)
 
-        # Set pixmap directly - scaling is handled by setScaledContents(True)
-        self.preview_label.setPixmap(pixmap)
+        # Scale pixmap to fit within the 16:9 container while preserving aspect ratio
+        scaled_pixmap = pixmap.scaled(
+            self.preview_label.size(),
+            Qt.AspectRatioMode.KeepAspectRatio,
+            Qt.TransformationMode.SmoothTransformation
+        )
+        self.preview_label.setPixmap(scaled_pixmap)
         self.preview_label.setText("")  # Clear text once image is displayed
 
 


### PR DESCRIPTION
This pull request modifies the preview image display to preserve the original image aspect ratio while fitting within the 16:9 aspect ratio preview_label container.

## Problem Addressed:

The previous implementation (PR #14) used `setScaledContents(True)` which would stretch images to fill the entire 16:9 preview area, potentially distorting images that don't have a 16:9 aspect ratio.

## Solution:

Implemented proper aspect ratio preservation that maintains the original image proportions while fitting within the 16:9 container.

## Changes Made:

### Preview Label Modifications:
- **Removed setScaledContents(True)**: This allows for manual control over image scaling and aspect ratio preservation
- **Maintained 16:9 Container**: The preview_label remains fixed at 768×432 pixels (16:9 aspect ratio)

### Display Method Improvements:
- **Aspect Ratio Preservation**: Implemented proper scaling using `Qt.AspectRatioMode.KeepAspectRatio`
- **Smooth Scaling**: Used `Qt.TransformationMode.SmoothTransformation` for high-quality image scaling
- **Fit Within Container**: Images are scaled to fit within the 16:9 container without distortion

## How It Works:

1. **Original Aspect Ratio Maintained**: Images keep their original width-to-height ratio
2. **Scaled to Fit**: Images are scaled down (or up) to fit within the 768×432 pixel container
3. **No Distortion**: Images are never stretched or squashed
4. **Letterboxing/Pillarboxing**: If the image aspect ratio doesn't match 16:9, there will be black bars:
   - **Letterboxing**: Horizontal black bars for wide images (wider than 16:9)
   - **Pillarboxing**: Vertical black bars for tall images (taller than 16:9)

## Benefits:

- ✅ **No Image Distortion**: Images maintain their original proportions
- ✅ **Consistent Preview Area**: The 16:9 container size remains constant
- ✅ **Proper Scaling**: High-quality smooth transformation scaling
- ✅ **Visual Accuracy**: Users see exactly how the image proportions will appear
- ✅ **Professional Appearance**: Letterboxing/pillarboxing is standard practice in video/image display

## Testing:

- ✅ All existing unit tests pass
- ✅ Image aspect ratio is preserved
- ✅ Images fit properly within the 16:9 container
- ✅ No breaking changes to existing functionality

## Technical Details:

- **Container Size**: 768×432 pixels (16:9 aspect ratio)
- **Scaling Mode**: `Qt.AspectRatioMode.KeepAspectRatio`
- **Transformation**: `Qt.TransformationMode.SmoothTransformation`
- **Image Format**: 16-bit grayscale TIFF files