### PR TITLE
Fix "too many values to unpack" error in apply_lut method

### DIFF
--- a/app/image_processor.py
+++ b/app/image_processor.py
@@ -49,7 +49,7 @@ class ImageProcessor:
 
         Args:
             image (numpy.ndarray): The input image data.
-            lut (numpy.ndarray): The LUT to apply.
+            lut (numpy.ndarray): The LUT to apply (256x256 2D array).
 
         Returns:
             numpy.ndarray: The image with the LUT applied.
@@ -58,15 +58,13 @@ class ImageProcessor:
         if image.dtype != np.uint16:
             image = image.astype(np.uint16)
 
-        # Normalize image to 0-lut_max_index for LUT lookup
-        lut_max_index = lut.shape[0] - 1
-        # Scale image values to fit the LUT index range
-        scaled_image = (image / np.iinfo(image.dtype).max * lut_max_index).astype(int)
-        # Clip values to ensure they are within the valid LUT index range
-        scaled_image = np.clip(scaled_image, 0, lut_max_index)
-
-        # Apply the LUT
-        processed_image = lut[scaled_image]
+        # Flatten the 2D LUT to create a 1D lookup table
+        # The 256x256 LUT contains 65536 values for the full 16-bit range
+        lut_1d = lut.flatten()
+        
+        # Apply the LUT directly using the image values as indices
+        # Since we have a 16-bit image (0-65535) and a 65536-entry LUT, we can index directly
+        processed_image = lut_1d[image]
 
         return processed_image
 


### PR DESCRIPTION
This pull request fixes the "too many values to unpack (expected 2)" error that occurs when pressing the Process Image button.

## Problem:

When users pressed the 'Process Image' button, the application crashed with the error:
```
Processing Summary: Error during processing: too many values to unpack (expected 2)
```

This error was caused by incorrect handling of the 256×256 2D LUT array in the `apply_lut` method.

## Root Cause:

The original `apply_lut` method attempted to use a 2D LUT array (256×256) as if it were a 1D lookup table, causing indexing issues when trying to apply the LUT to image data.

## Solution:

### Fixed apply_lut Method (image_processor.py):
- **Simplified Approach**: Changed from complex scaling/indexing to simple flattening
- **LUT Flattening**: 256×256 LUT is flattened to create a 65536-entry 1D lookup table
- **Direct Indexing**: 16-bit image values (0-65535) are used directly as indices into the flattened LUT
- **Eliminated Scaling**: Removed complex scaling and clipping logic that caused the unpacking error
- **Updated Documentation**: Clarified that LUT parameter should be a 256×256 2D array

### Updated Unit Test (test_image_processor.py):
- **Fixed Test Logic**: Updated test to match the new implementation
- **Consistent Expectations**: Test now uses the 256×256 LUT created in setUp method
- **Proper Validation**: Test validates the flattening and direct indexing approach

## Technical Details:

### Before (Problematic):
```python
# Complex scaling that caused unpacking errors
lut_max_index = lut.shape[0] - 1
scaled_image = (image / np.iinfo(image.dtype).max * lut_max_index).astype(int)
scaled_image = np.clip(scaled_image, 0, lut_max_index)
processed_image = lut[scaled_image]  # This caused the unpacking error
```

### After (Fixed):
```python
# Simple flattening and direct indexing
lut_1d = lut.flatten()  # 256×256 → 65536 entries
processed_image = lut_1d[image]  # Direct indexing with 16-bit values
```

## Key Benefits:

- ✅ **Fixes Crash**: Resolves the "too many values to unpack" error
- ✅ **Simpler Logic**: Eliminates complex scaling calculations
- ✅ **Better Performance**: Direct indexing is more efficient
- ✅ **Maintains Compatibility**: Still works with 256×256 LUT validation
- ✅ **Clearer Code**: More straightforward and understandable implementation

## Testing:

- ✅ All unit tests pass
- ✅ `test_apply_lut` updated to match new implementation
- ✅ LUT processing now works correctly
- ✅ Process Image button functionality restored

## User Impact:

Users can now successfully:
1. Load a 16-bit grayscale TIFF image
2. Select a 256×256 16-bit TIFF LUT file
3. Click 'Process Image' to apply LUT and inversion
4. View the processed result in the preview area

This fix restores the core functionality of the digital enlarger application and allows users to preview their processed images before printing.