### PR TITLE
Fix preview image distortion by eliminating double scaling

### DIFF
--- a/app/controller.py
+++ b/app/controller.py
@@ -75,7 +75,7 @@ class Controller:
             # Use preview manager for fast preview display
             preview_pixmap = self.preview_manager.create_preview_pixmap(
                 self.loaded_image, 
-                container_size=(400, 225)  # 16:9 aspect ratio container (matches 8K screen 7680×4320)
+                container_size=(768, 432)  # Match actual preview_label size (16:9 aspect ratio)
             )
             
             # Display in preview area

--- a/tests/test_preview_image_manager.py
+++ b/tests/test_preview_image_manager.py
@@ -71,7 +71,7 @@ class TestPreviewImageManager(unittest.TestCase):
         manager = PreviewImageManager(cv2_resize=mock_resize)
         
         # WHEN: Preparing preview image
-        result = manager.prepare_preview_image(large_image, container_size=(400, 225))
+        result = manager.prepare_preview_image(large_image, container_size=(768, 432))
         
         # THEN: cv2.resize was called with correct parameters
         mock_resize.assert_called_once()
@@ -114,15 +114,15 @@ class TestPreviewImageManager(unittest.TestCase):
         """
         # GIVEN: Portrait image (taller than wide)
         image_shape = (1200, 800)  # height, width
-        container_size = (400, 225)  # width, height (16:9 aspect ratio)
+        container_size = (768, 432)  # width, height (16:9 aspect ratio - matches preview_label)
         
         # WHEN: Calculating preview size
         result = self.manager.calculate_preview_size(image_shape, container_size)
         
         # THEN: Size maintains aspect ratio and fits in container
         width, height = result
-        self.assertEqual(width, 150)  # Limited by height: 225 * (800/1200) = 150
-        self.assertEqual(height, 225)  # Uses full container height
+        self.assertEqual(width, 288)  # Limited by height: 432 * (800/1200) = 288
+        self.assertEqual(height, 432)  # Uses full container height
         
         # Verify aspect ratio is maintained
         original_ratio = 800 / 1200
@@ -137,15 +137,15 @@ class TestPreviewImageManager(unittest.TestCase):
         """
         # GIVEN: Landscape image (wider than tall)
         image_shape = (600, 1200)  # height, width
-        container_size = (400, 225)  # width, height (16:9 aspect ratio)
+        container_size = (768, 432)  # width, height (16:9 aspect ratio - matches preview_label)
         
         # WHEN: Calculating preview size
         result = self.manager.calculate_preview_size(image_shape, container_size)
         
         # THEN: Size maintains aspect ratio and fits in container
         width, height = result
-        self.assertEqual(width, 400)  # Uses full container width
-        self.assertEqual(height, 200)  # Limited by width: 400 * (600/1200) = 200
+        self.assertEqual(width, 768)  # Uses full container width
+        self.assertEqual(height, 384)  # Limited by width: 768 * (600/1200) = 384
 
     # Tests for Pixmap Creation
 


### PR DESCRIPTION
## 🎯 **Problem Fixed**

The preview image was distorted due to **double scaling** in the processing pipeline:
1. PreviewImageManager scaled images to 400×225
2. Qt then scaled 400×225 to 768×432 (preview_label size)

This double interpolation caused quality loss and visual artifacts.

## ✅ **Solution Implemented**

### **Eliminated Double Scaling:**
- **Before**: Original → 400×225 (cv2) → 768×432 (Qt) = **Double scaling**
- **After**: Original → 768×432 (cv2) → Display = **Single scaling**

### **Changes Made:**
- Updated `container_size` from `(400, 225)` to `(768, 432)` in controller
- Container now matches actual `preview_label` dimensions exactly
- Updated unit tests with correct expected values for new scaling
- Recalculated test expectations for portrait and landscape images

### **Files Modified:**
- `app/controller.py` - Updated container_size to match preview_label
- `tests/test_preview_image_manager.py` - Updated test cases and expected results

## 🚀 **Benefits Achieved**

### **Image Quality:**
- ✅ **No double interpolation artifacts**
- ✅ **Better image clarity** with single scaling operation
- ✅ **Preserved image quality** from source to display
- ✅ **Consistent scaling algorithm** (cv2.INTER_LINEAR throughout)

### **Performance:**
- ✅ **50% fewer scaling operations**
- ✅ **More efficient processing** pipeline
- ✅ **Direct scaling** from original to final size
- ✅ **No unnecessary Qt scaling** overhead

### **Technical:**
- ✅ **Container matches display**: 768×432 = 768×432
- ✅ **All image orientations work**: Portrait, landscape, square
- ✅ **Aspect ratio preservation** maintained
- ✅ **All unit tests passing** with updated expectations

## 🧪 **Testing**

- All preview size calculations verified
- Unit tests updated and passing
- Single scaling confirmed (no Qt scaling needed)
- Image quality improvements validated

This fix ensures preview images display with optimal quality and no distortion artifacts.